### PR TITLE
Add to ToANSIChar command

### DIFF
--- a/SHOWOFF-NVSE/ShowOffNVSE.cpp
+++ b/SHOWOFF-NVSE/ShowOffNVSE.cpp
@@ -744,6 +744,9 @@ extern "C"
 		/*3D63*/	REG_CMD(ApplyEasingAlt);
 		/*3D64*/	REG_CMD(PatchFreezeTime);
 		/*3D65*/	REG_CMD_FORM(PlaceAtReticleAlt);
+
+		//========v1.82
+		/*3D66*/	REG_CMD_STR(ToANSIChar)
 		
 		//========v1.??
 		//todo: always check to update/increase your opcode range when adding new functions


### PR DESCRIPTION
Adds ToANSIChar command that translates DirectX Scancodes to corresponding char depending on user's current keyboard layout and returns it as string. 
Ignores Shift state by default (can be changed using optional argument) and returns char in lowercase (reason is in comment).

