### PR TITLE
Add GetWorldOffsetPosArray

### DIFF
--- a/SHOWOFF-NVSE/Changelog.txt
+++ b/SHOWOFF-NVSE/Changelog.txt
@@ -468,6 +468,17 @@ In order to filter those out, there is now a new flag: NoSlotlessItems
 ===Function changes:
 * Added optional WriteToJson argument to specify formatting compact/pretty
 
+
+//===v1.82
+===Bug Fixes:
+*
+
+===New Functions:
+* GetWorldOffsetPosArray
+
+===Function changes:
+*
+
 ====== (Template:)
 
 //===v???

--- a/SHOWOFF-NVSE/ShowOffNVSE.cpp
+++ b/SHOWOFF-NVSE/ShowOffNVSE.cpp
@@ -38,7 +38,7 @@
 // Plugin Stuff
 IDebugLog g_Log; // file will be open after NVSE plugin load
 HMODULE	g_ShowOffHandle;
-constexpr UInt32 g_PluginVersion = 181;
+constexpr UInt32 g_PluginVersion = 182;
 
 //***Current Max OpCode (https://geckwiki.com/index.php?title=NVSE_Opcode_Base)
 const UInt32 MaxOpcode = 0x3D74;
@@ -745,8 +745,12 @@ extern "C"
 		/*3D64*/	REG_CMD(PatchFreezeTime);
 		/*3D65*/	REG_CMD_FORM(PlaceAtReticleAlt);
 		
+		//========v1.82
+		/*3D66*/ REG_CMD_ARR(GetWorldOffsetPosArray);
+		
 		//========v1.??
 		//todo: always check to update/increase your opcode range when adding new functions
+
 
 
 #if EnableSafeExtractArgsTests

--- a/SHOWOFF-NVSE/functions/SO_fn_Refs.h
+++ b/SHOWOFF-NVSE/functions/SO_fn_Refs.h
@@ -115,8 +115,8 @@ bool Cmd_GetWorldOffsetPosArray_Execute(COMMAND_ARGS)
 	ArrayElementL posElems[3] = {};
 
 	if (thisObj->parentCell && thisObj->parentCell->worldSpace) {
-		posElems[0] = thisObj->posX + thisObj->parentCell->worldSpace->worldMapCellX;
-		posElems[1] = thisObj->posY + thisObj->parentCell->worldSpace->worldMapCellY;
+		posElems[0] = (thisObj->posX / thisObj->parentCell->worldSpace->worldMapScale) + thisObj->parentCell->worldSpace->worldMapCellX;
+		posElems[1] = (thisObj->posY / thisObj->parentCell->worldSpace->worldMapScale) + thisObj->parentCell->worldSpace->worldMapCellY;
 	} else {
 		posElems[0] = thisObj->posX;
 		posElems[1] = thisObj->posY;

--- a/SHOWOFF-NVSE/functions/SO_fn_Refs.h
+++ b/SHOWOFF-NVSE/functions/SO_fn_Refs.h
@@ -108,3 +108,21 @@ bool Cmd_PlaceAtReticleAlt_Execute(COMMAND_ARGS)
 
 	return true;
 }
+DEFINE_COMMAND_PLUGIN(GetWorldOffsetPosArray, "Returns an array of the 3 axis positions of a reference based on the worldspace offsets",
+	true, nullptr);
+bool Cmd_GetWorldOffsetPosArray_Execute(COMMAND_ARGS)
+{
+	ArrayElementL posElems[3] = {};
+
+	if (thisObj->parentCell && thisObj->parentCell->worldSpace) {
+		posElems[0] = thisObj->posX + thisObj->parentCell->worldSpace->worldMapCellX;
+		posElems[1] = thisObj->posY + thisObj->parentCell->worldSpace->worldMapCellY;
+	} else {
+		posElems[0] = thisObj->posX;
+		posElems[1] = thisObj->posY;
+	}
+	posElems[2] = thisObj->posZ;
+	auto const arr = g_arrInterface->CreateArray(posElems, 3, scriptObj);
+	g_arrInterface->AssignCommandResult(arr, result);
+	return true;
+}


### PR DESCRIPTION
Gets the ref position + worldspace x/y offsets.

If there is no parent cell or worldspace returns the same as `GetPosArray`

idk if the func name or description is good enough but yeah ¯\\_(ツ)_/¯

Anyway, the idea is to be able to get relatively accurate positioning relative to the highest level worldspace for standardized calcs across child worldspaces.

Use case is my Fast Travel Expenses - I need to get as accurate calculations as possible when computing distance from one child worldspace into another.