### PR TITLE
Add BaseCopyFaceGenFrom command and related NPC methods

### DIFF
--- a/SHOWOFF-NVSE/ShowOffNVSE.cpp
+++ b/SHOWOFF-NVSE/ShowOffNVSE.cpp
@@ -748,6 +748,9 @@ extern "C"
 		//========v1.82
 		/*3D66*/	REG_CMD_STR(ToANSIChar);
 		/*3D67*/ 	REG_CMD_ARR(GetWorldOffsetPosArray);
+
+		//========v1.83
+		/*3D68*/	REG_CMD(BaseCopyFaceGenFrom);
 		
 		//========v1.??
 		//todo: always check to update/increase your opcode range when adding new functions

--- a/SHOWOFF-NVSE/functions/SO_fn_Actors.h
+++ b/SHOWOFF-NVSE/functions/SO_fn_Actors.h
@@ -845,6 +845,21 @@ bool Cmd_IsActorInvisibleToPlayer_Execute(COMMAND_ARGS)
 	return Cmd_IsActorInvisibleToPlayer_Eval(thisObj, nullptr, nullptr, result);
 }
 
+DEFINE_COMMAND_PLUGIN(BaseCopyFaceGenFrom, "", false, kParams_TwoActorBases);
+bool Cmd_BaseCopyFaceGenFrom_Execute(COMMAND_ARGS)
+{
+	TESNPC* srcNPC = nullptr;
+	TESNPC* destNPC = nullptr;
+	*result = 0;
+	if (ExtractArgsEx(EXTRACT_ARGS_EX, &srcNPC, &destNPC) && srcNPC && IS_ID(srcNPC, TESNPC) && destNPC && IS_ID(destNPC, TESNPC))
+	{
+		destNPC->SetSex(srcNPC->baseData.flags);
+		destNPC->SetRace(srcNPC->race.race);
+		destNPC->CopyAppearance(srcNPC);
+		*result = 1;
+	}
+	return true;
+}
 
 #ifdef _DEBUG
 

--- a/nvse/GameForms.cpp
+++ b/nvse/GameForms.cpp
@@ -965,3 +965,35 @@ UInt32 TESIdleForm::GetSequenceID() const
 {
 	return data.groupFlags & 0x3F; // copying code at 0x5FF160
 }
+
+void TESNPC::SetSex(UInt32 flags)
+{
+	TESActorBaseData* baseDataPtr = &this->baseData;
+
+	UInt32 currentSexBit = baseDataPtr->flags & TESActorBaseData::kFlags_Female;
+	UInt32 newSexBit = flags & TESActorBaseData::kFlags_Female;
+
+	if (currentSexBit == newSexBit) 
+		return;
+
+	ThisStdCall(0x47DD50, baseDataPtr, 1, newSexBit, 1);
+}
+
+void TESNPC::SetRace(TESRace* pRace)
+{
+	if (this->race.race == pRace)
+		return;
+
+	PlayerCharacter* player = PlayerCharacter::GetSingleton();
+	if (player && player->baseForm == this) {
+		ThisStdCall(0x60B240, this, pRace, 0);
+	}
+	else {
+		this->race.race = pRace;
+	}
+}
+
+void TESNPC::CopyAppearance(TESNPC* srcNPC)
+{
+	ThisStdCall(0x603790, this, srcNPC);
+}

--- a/nvse/ParamInfos.h
+++ b/nvse/ParamInfos.h
@@ -662,6 +662,12 @@ static ParamInfo kParams_OneOptionalActorBase[1] =
 	{	"base actor",	kParamType_ActorBase,	1	},
 };
 
+static ParamInfo kParams_TwoActorBases[2] =
+{
+	{	"base actor",	kParamType_ActorBase,	0	},
+	{	"base actor",	kParamType_ActorBase,	0	},
+};
+
 static ParamInfo kParams_OneFloat_OneOptionalActorBase[2] =
 {
 	{	"float",		kParamType_Float,		0	},


### PR DESCRIPTION
Adds BaseCopyFaceGenFrom command similar to [CopyFaceGenFrom](https://geckwiki.com/index.php/CopyFaceGenFrom) with two differences:
  1. Works on base form instead of ref.
  2. Does not store backup changes.

Usage: 
  BaseCopyFaceGenFrom srcNPC destNPC

Example:
  BaseCopyFaceGenFrom Benny CraigBoone ; Copies appearance from Benny to Boone