### PR TITLE
Add GetSpellUsageNumEx command and implementation

### DIFF
--- a/SHOWOFF-NVSE/ShowOffNVSE.cpp
+++ b/SHOWOFF-NVSE/ShowOffNVSE.cpp
@@ -748,9 +748,8 @@ extern "C"
 		//========v1.82
 		/*3D66*/	REG_CMD_STR(ToANSIChar);
 		/*3D67*/ 	REG_CMD_ARR(GetWorldOffsetPosArray);
-
-		//========v1.83
 		/*3D68*/	REG_CMD(BaseCopyFaceGenFrom);
+		/*3D69*/	REG_CMD(GetSpellUsageNumEx);
 		
 		//========v1.??
 		//todo: always check to update/increase your opcode range when adding new functions

--- a/SHOWOFF-NVSE/ShowOffNVSE.h
+++ b/SHOWOFF-NVSE/ShowOffNVSE.h
@@ -11,6 +11,7 @@
 #include "GameUI.h" 
 #include "common/ICriticalSection.h"
 #include "GameData.h"
+#include "GameEffects.h"
 #include "decoding.h"
 #include "SOTypes.h"
 #include "InventoryRef.h"

--- a/SHOWOFF-NVSE/functions/SO_fn_Items.h
+++ b/SHOWOFF-NVSE/functions/SO_fn_Items.h
@@ -680,14 +680,42 @@ bool Cmd_GetItemHotkeyIconPath_Execute(COMMAND_ARGS)
 	return true;
 }
 
+DEFINE_COMMAND_PLUGIN(GetSpellUsageNumEx, "", true, kParams_JIP_OneMagicItem);
+bool Cmd_GetSpellUsageNumEx_Execute(COMMAND_ARGS)
+{
+	*result = 0.0;
 
+	if (!thisObj || !thisObj->IsActor())
+		return true;
 
+	MagicItem* magicItem = nullptr;
+	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &magicItem))
+		return true;
 
+	EffectItem* usageMonitorEffect = ThisStdCall<EffectItem*>(0x00406200, &magicItem->list);	// GetUsageMonitorEffect
+	if (!usageMonitorEffect)
+		return true;
 
+	float totalMagnitude = 0.0f;
+	auto* actor = static_cast<Actor*>(thisObj);
+	MagicTarget* target = &actor->magicTarget;
 
+	auto* effectList = target->GetEffectList();
+	if (!effectList)
+		return true;
 
+	for (auto* iter = effectList->Head(); iter; iter = iter->next)
+	{
+		ActiveEffect* activeEff = iter->data;
+		if (!activeEff || activeEff->effectItem != usageMonitorEffect || activeEff->magicItem != magicItem)
+			continue;
 
+		totalMagnitude += activeEff->magnitude;
+	}
+	*result = totalMagnitude;
 
+	return true;
+}
 
 #if _DEBUG
 


### PR DESCRIPTION
Similar to [GetSpellUsageNum](https://geckwiki.com/index.php?title=GetSpellUsageNum) command but returns number of times an Ingestible has been used by an actor even if its effect currently not active.

Helps with calculating real addiction chance of chem.