### PR TITLE
fix AuxTimerStart crash during DoCountdown iteration

### DIFF
--- a/SHOWOFF-NVSE/AuxTimers.h
+++ b/SHOWOFF-NVSE/AuxTimers.h
@@ -140,10 +140,26 @@ namespace AuxTimer
 		std::string	varName;
 	};
 
+	//deferred insertion for timers created during DoCountdown iteration
+	//inserting into UnorderedMap mid-iteration can rehash and invalidate iterators
+	struct AuxTimerPendingInsertion
+	{
+		UInt32		modIndex;
+		UInt32		ownerID;
+		std::string	varName;
+		bool		isPerm;
+		double		timeToCountdown;
+		UInt32		flags;
+	};
+
+	extern bool g_isIteratingTimers;
+	extern std::vector<AuxTimerPendingInsertion> g_auxTimersPendingInsertion;
+
 	extern std::vector<AuxTimerPendingRemoval> g_auxTimersToRemovePerm, g_auxTimersToRemoveTemp;
 	namespace Impl
 	{
 		void RemovePendingTimers(bool clearTemp);
 	}
 	void RemovePendingTimers();
+	void InsertPendingTimers();
 }

--- a/SHOWOFF-NVSE/ShowOffNVSE.cpp
+++ b/SHOWOFF-NVSE/ShowOffNVSE.cpp
@@ -298,10 +298,10 @@ void MessageHandler(NVSEMessagingInterface::Message* msg)
 			const auto isMenuMode = CdeclCall<bool>(0x702360);
 
 			AUX_TIMER_CS;
-			AuxTimer::RemovePendingTimers();
 			if (!s_auxTimerMapArraysPerm.Empty())
 				s_dataChangedFlags |= kChangedFlag_AuxTimerMaps; // assume a timer will change
 			AuxTimer::DoCountdown(globalTimeMult, vatsTimeMult, isMenuMode);
+			AuxTimer::RemovePendingTimers();
 		}
 
 		break;

--- a/SHOWOFF-NVSE/functions/SO_fn_AuxTimer.h
+++ b/SHOWOFF-NVSE/functions/SO_fn_AuxTimer.h
@@ -34,6 +34,24 @@ bool Cmd_AuxTimerStart_Execute(COMMAND_ARGS)
 			{
 				if (timeToCountdown == -1.0)
 					return true; //todo: dispatch xNVSE error
+
+				//can't insert into UnorderedMap mid-iteration, would invalidate iterators
+				if (g_isIteratingTimers)
+				{
+					g_auxTimersPendingInsertion.emplace_back(AuxTimerPendingInsertion{
+						varInfo.modIndex, varInfo.ownerID, varName,
+						varInfo.isPerm, timeToCountdown, flags
+					});
+					if (varInfo.isPerm)
+					{
+						s_dataChangedFlags |= kChangedFlag_AuxTimerMaps;
+						if (thisObj)
+							thisObj->MarkAsModified(0);
+					}
+					*result = 1;
+					return true;
+				}
+
 				value = GetTimerValue(varInfo, true);
 			}
 

--- a/SHOWOFF-NVSE/internal/AuxTimers.cpp
+++ b/SHOWOFF-NVSE/internal/AuxTimers.cpp
@@ -12,6 +12,9 @@ namespace AuxTimer
 
 	std::vector<AuxTimerPendingRemoval> g_auxTimersToRemovePerm, g_auxTimersToRemoveTemp;
 
+	bool g_isIteratingTimers = false;
+	std::vector<AuxTimerPendingInsertion> g_auxTimersPendingInsertion;
+
 	AuxTimerValue* __fastcall GetTimerValue(const AuxTimerMapInfo& varInfo, bool createIfNotFound)
 	{
 		if (createIfNotFound) {
@@ -168,8 +171,11 @@ namespace AuxTimer
 
 	void DoCountdown(double globalTimeMult, double vatsTimeMult, bool isMenuMode)
 	{
+		g_isIteratingTimers = true;
 		Impl::DoCountdown(globalTimeMult, vatsTimeMult, isMenuMode, true);
 		Impl::DoCountdown(globalTimeMult, vatsTimeMult, isMenuMode, false);
+		g_isIteratingTimers = false;
+		InsertPendingTimers();
 	}
 
 	void HandleAutoRemoveTempTimers()
@@ -238,6 +244,21 @@ namespace AuxTimer
 	{
 		Impl::RemovePendingTimers(true);
 		Impl::RemovePendingTimers(false);
+	}
+
+	void InsertPendingTimers()
+	{
+		if (g_auxTimersPendingInsertion.empty())
+			return;
+
+		for (auto& pending : g_auxTimersPendingInsertion)
+		{
+			auto& modsMap = pending.isPerm ? s_auxTimerMapArraysPerm : s_auxTimerMapArraysTemp;
+			auto& entry = modsMap[pending.modIndex][pending.ownerID][const_cast<char*>(pending.varName.c_str())];
+			entry.SetTimeToCountdown(pending.timeToCountdown);
+			entry.m_flags = pending.flags;
+		}
+		g_auxTimersPendingInsertion.clear();
 	}
 }
 


### PR DESCRIPTION
AuxTimerStart called from OnAuxTimerUpdate/OnAuxTimerStop handlers would insert into UnorderedMap mid-iteration, rehashing and invalidating active iterators. Defer new timer insertion until after DoCountdown completes, matching the existing pattern used for pending removals. Also swap RemovePendingTimers to run after DoCountdown so timers flagged during countdown get cleaned up on the same frame.